### PR TITLE
Imageコンポーネントの作成

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
     schedule:
-      interval: 'daily'
+      interval: "daily"

--- a/src/common/Image.jsx
+++ b/src/common/Image.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import "./css/Image.css";
+
+export default function Image(props) {
+  return (
+    <img
+      src={props.src}
+      alt={props.alt}
+      className={props.class}
+      id={props.id}
+    />
+  );
+}

--- a/src/common/css/Image.css
+++ b/src/common/css/Image.css
@@ -1,0 +1,6 @@
+img {
+  grid-area: image;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}

--- a/src/quiz/Description.jsx
+++ b/src/quiz/Description.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import "./css/quiz.css";
 import "./css/Description.css";
+import Image from "../common/Image";
 import Timer from "../common/Timer";
 
 export default function Description() {
@@ -74,7 +75,10 @@ export default function Description() {
   return (
     <div id="description">
       <div className="title">この画像を説明しよう</div>
-      <img src="https://source.unsplash.com/featured/?lion" alt="問題の画像" />
+      <Image
+        src="https://source.unsplash.com/featured/?lion"
+        alt="問題の画像"
+      />
       <div className="textBox otherDescription">
         AIの説明文
         <p>{data.playerId[0].aiDescription}</p>

--- a/src/quiz/css/quiz.css
+++ b/src/quiz/css/quiz.css
@@ -15,13 +15,6 @@ body {
   text-align: center;
 }
 
-img {
-  grid-area: image;
-  height: 100%;
-  object-fit: cover;
-  width: 100%;
-}
-
 .textBox {
   border: solid 0.5vh black;
   box-sizing: border-box;


### PR DESCRIPTION
## 実装内容
画像表示コンポーネント（Imageコンポーネント）を作成
コンポーネント作成による他ファイルのリファクタリング

## スクリーンショット・キャプチャ
見た目の変化なし

## チェックリスト

- [x] エラーが発生していない
- [x] セルフレビュー

## 保留にした項目や TODO リスト


## 備考
Description.cssの時はclassとidは使ってませんが、他のファイルで使うのでpropsを用意してあります
idがprops.idとなって一見バグりそうですが、テストして普通に反映できていたので大丈夫です

## UIの画像 または Figmaの該当URL（なければ: なし）
なし

## 対応 Issue

resolve: #55 
