### PR TITLE
リンクの付け忘れを追加

### DIFF
--- a/src/quiz/Description.jsx
+++ b/src/quiz/Description.jsx
@@ -65,7 +65,7 @@ export default function Description() {
         setAttentionMessage("NGワードが含まれています");
         return 0;
       }
-    history.push("/answer");
+    history.push("/quiz/answer");
   };
 
   useEffect(() => {


### PR DESCRIPTION
## 実装内容
Answerへのリンクが直ってなかったので修正
/answerをquiz/answerに変更
もう1個の方を直せてませんでした

## スクリーンショット・キャプチャ
見た目の変化なし

## チェックリスト

- [x] エラーが発生していない
- [x] セルフレビュー

## 保留にした項目や TODO リスト


## 備考


## UIの画像 または Figmaの該当URL（なければ: なし）
なし

## 対応 Issue

resolve: #76 
