### PR TITLE
説明記入欄のタイムアップ後に入力できないよう変更・初期値を設定

### DIFF
--- a/src/quiz/pages/Description.jsx
+++ b/src/quiz/pages/Description.jsx
@@ -59,6 +59,7 @@ export default function Description() {
 
   if (time === 0) {
     clearInterval(timer.current);
+    document.getElementById("myDescription").disabled = true;
     setTimeout(() => {
       history.push("/quiz/answer");
     }, 5000);
@@ -78,7 +79,9 @@ export default function Description() {
             type="text"
             value={myDescription}
             onChange={handleChange}
+            placeholder="説明文を記入してね"
             className="textBox"
+            id="myDescription"
           />
         </form>
         <Timer time={time} />


### PR DESCRIPTION
<!-- Create pull requestを押す前に上の Preview で確認してください！ -->
<!-- 各コメントの下に項目を書いていってください！ -->
## Issueへのリンク
<!-- #Issue番号 -->
#128

## やったこと
<!-- このプルリクで何をしたのか？ -->
タイムアップ後にinputのdisableをtrueに変更
inputのplacehonlderに文字を設定

## 変更内容
<!-- UIの変更ならスクリーンショット
     APIの変更ならリクエストとレスポンス -->
![image](https://user-images.githubusercontent.com/65590892/132817888-bcf10227-97a4-41e8-bbee-5850b59025b1.png)


## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「なし」でOK）（やらない場合は、いつやるのかを明記する。） -->
なし

## できるようになること（ユーザ目線）（APIなら開発者目線）
<!-- 何ができるようになるのか？（あれば。無いなら「なし」でOK） -->
なし

## できなくなること（ユーザ目線）（APIなら開発者目線）
<!-- 何ができなくなるのか？（あれば。無いなら「なし」でOK） -->
タイムアップ後の説明記入

## 動作確認
<!-- どのような動作確認を行ったのか？結果はどうか？ -->
タイムアップ後に説明欄への記入を試みた 結果：記入できなかった

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）（あれば。無いなら「なし」でOK）-->
なし

<!-- Create pull request を押す前に上の Preview で確認してください！ -->
<!-- 画像が大きい場合は img タグを使用して大きさを決めてください！ -->
