### PR TITLE
警告メッセージに影響していたpタグのmarginのcssを移動

### DIFF
--- a/src/common/components/css/AttentionMessage.css
+++ b/src/common/components/css/AttentionMessage.css
@@ -6,5 +6,4 @@
   grid-area: attentionMessage;
   justify-content: center;
   line-height: 4vh;
-  margin: 0;
 }

--- a/src/common/components/css/textBox.css
+++ b/src/common/components/css/textBox.css
@@ -5,3 +5,8 @@
   font-size: 4vh;
   padding: 2vh;
 }
+
+.textBox p {
+  font-size: 5vh;
+  margin: 2vh 0 0 4vh;
+}

--- a/src/quiz/pages/css/Answer.css
+++ b/src/quiz/pages/css/Answer.css
@@ -6,7 +6,6 @@
     "... otherDescription ..." 20vh
     "... ................ ..." 1vh
     "... attentionMessage ..." 4vh
-    "... ................ ..." 1vh
     "... answerForm       ..." 90vh
     / auto 135vh auto;
 }

--- a/src/quiz/pages/css/quiz.css
+++ b/src/quiz/pages/css/quiz.css
@@ -12,11 +12,6 @@
   width: 100%;
 }
 
-.quiz p {
-  font-size: 5vh;
-  margin: 2vh 0 0 4vh;
-}
-
 .quiz input[type="submit"] {
   align-items: center;
   background-color: #ff6347;


### PR DESCRIPTION
<!-- Create pull requestを押す前に上の Preview で確認してください！ -->
<!-- 各コメントの下に項目を書いていってください！ -->
## Issueへのリンク
<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue -->
<!-- resolve: #Issue番号 -->
resolve: #156

## やったこと
<!-- このプルリクで何をしたのか？ -->
attentionMesseageコンポーネントにかかっているmarginを削除
quiz.cssにあったpタグのcssをtextBoxへ移動
それに伴いずれた警告メッセージのずれを一部修正（Answer.css）

## 変更内容
<!-- UIの変更ならスクリーンショット
     APIの変更ならリクエストとレスポンス -->
![image](https://user-images.githubusercontent.com/65590892/133339340-8882c78e-face-45bd-9735-24767affe021.png)
細かいので伝わりにくい

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「なし」でOK）（やらない場合は、いつやるのかを明記する。） -->
なし

## できるようになること（ユーザ目線）（APIなら開発者目線）
<!-- 何ができるようになるのか？（あれば。無いなら「なし」でOK） -->
なし

## できなくなること（ユーザ目線）（APIなら開発者目線）
<!-- 何ができなくなるのか？（あれば。無いなら「なし」でOK） -->
なし

## 動作確認
<!-- どのような動作確認を行ったのか？結果はどうか？ -->
前ページを回った 結果：ちゃんと警告メッセージが意図した位置に配置されていた

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）（あれば。無いなら「なし」でOK）-->
なし

<!-- Create pull request を押す前に上の Preview で確認してください！ -->
<!-- 画像が大きい場合は img タグを使用して大きさを決めてください！ -->
## チェックリスト

- [x] タイトルをちゃんと設定できている
- [x] Assignerの設定ができている
- [x] Linked issuesの設定ができている
